### PR TITLE
Prefer to return strings and maps, slice prefixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/src/index.d.ts",
   "scripts": {
     "test": "npm-run-all --parallel test:lint test:unit",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"es6\"}' mocha --compilers ts:ts-node/register --timeout 20000 -r test/_setup.ts test/*.test.ts",
+    "test:unit": "mocha --compilers ts:ts-node/register --timeout 20000 -r test/_setup.ts test/*.test.ts",
     "test:lint": "tslint --type-check --project tsconfig.json '{src,test}/**/*.ts'",
     "update-proto": "node ./bin/update-proto ./proto && node bin/generate-methods.js ./proto/rpc.proto > src/rpc.ts",
     "build:doc": "rm -rf docs && typedoc --exclude \"**/test/*\" --excludePrivate --out ./docs ./src/index.ts && node bin/tame-typedoc",

--- a/src/util.ts
+++ b/src/util.ts
@@ -49,21 +49,21 @@ export function forOwn<T>(obj: T, iterator: <K extends keyof T>(value: T[K], key
 export abstract class PromiseWrap<T> implements PromiseLike<T> {
 
   /**
-   * exec should be override to run the promised action.
+   * createPromise should ben override to run the promised action.
    */
-  public abstract exec(): Promise<T>;
+  protected abstract createPromise(): Promise<T>;
 
   /**
    * then implements Promiselike.then()
    */
   public then<R, V>(onFulfilled: (value: T) => R | Promise<R>, onRejected?: (err: any) => V | Promise<V>): Promise<R | V> {
-    return this.exec().then(onFulfilled, <any> onRejected);
+    return this.createPromise().then(onFulfilled, <any> onRejected);
   }
 
   /**
    * catch implements Promiselike.catch()
    */
   public catch<R>(onRejected: (err: any) => R | Promise<R>): Promise<R> {
-    return this.exec().catch(onRejected);
+    return this.createPromise().catch(onRejected);
   }
 }

--- a/test/kv.test.ts
+++ b/test/kv.test.ts
@@ -25,8 +25,8 @@ describe('connection pool', () => {
     ]);
   });
 
-  afterEach(() => {
-    client.delete().all();
+  afterEach(async () => {
+    await client.delete().all();
     client.close();
     badClient.close();
   });
@@ -66,6 +66,15 @@ describe('connection pool', () => {
         o1: 'bar1',
         o2: 'bar2',
         o3: '{"value":"bar3"}',
+      });
+    });
+
+    it('supports wide utf8 characters in prefixes', async () => {
+      // These characters are >16 bits, if they're sliced in the wrong order
+      // (based on string rather than byte length) the prefix can get truncated.
+      await client.put('❤️/💔').value('heyo!');
+      expect(await client.getAll().prefix('❤️/')).to.deep.equal({
+        '💔': 'heyo!',
       });
     });
 

--- a/test/kv.test.ts
+++ b/test/kv.test.ts
@@ -46,7 +46,12 @@ describe('connection pool', () => {
 
   describe('get() / getAll()', () => {
     it('lists all values', async () => {
-      expect(await client.getAll().strings()).to.containSubset(['bar1', 'bar2', 'bar5']);
+      expect(await client.getAll().strings()).to.deep.equal({
+        foo1: 'bar1',
+        foo2: 'bar2',
+        foo3: '{"value":"bar3"}',
+        baz: 'bar5',
+      });
     });
 
     it('gets single keys with various encoding', async () => {
@@ -57,12 +62,21 @@ describe('connection pool', () => {
     });
 
     it('queries prefixes', async () => {
-      expect(await client.getAll().prefix('foo').strings())
-        .to.have.members(['bar1', 'bar2', '{"value":"bar3"}']);
+      expect(await client.getAll().prefix('fo').strings()).to.deep.equal({
+        o1: 'bar1',
+        o2: 'bar2',
+        o3: '{"value":"bar3"}',
+      });
     });
 
     it('gets keys', async () => {
-      expect(await client.getAll().keys().strings()).to.have.members(['foo1', 'foo2', 'foo3', 'baz']);
+      expect(await client.getAll().keys()).to.have.members(['foo1', 'foo2', 'foo3', 'baz']);
+      expect(await client.getAll().keyBuffers()).to.have.deep.members([
+        Buffer.from('foo1'),
+        Buffer.from('foo2'),
+        Buffer.from('foo3'),
+        Buffer.from('baz'),
+      ]);
     });
 
     it('counts', async () => {
@@ -74,17 +88,15 @@ describe('connection pool', () => {
         .prefix('foo')
         .sort('key', 'asc')
         .limit(2)
-        .keys()
-        .strings(),
-      ).to.deep.equal(['foo1', 'foo2']);
+        .keys(),
+      ).to.deep.equal(['1', '2']);
 
       expect(await client.getAll()
         .prefix('foo')
         .sort('key', 'desc')
         .limit(2)
-        .keys()
-        .strings(),
-      ).to.deep.equal(['foo3', 'foo2']);
+        .keys(),
+      ).to.deep.equal(['3', '2']);
     });
   });
 
@@ -96,7 +108,7 @@ describe('connection pool', () => {
 
     it('deletes prefix', async () => {
       await client.delete().prefix('foo');
-      expect(await client.getAll().keys().strings()).to.deep.equal(['baz']);
+      expect(await client.getAll().keys()).to.deep.equal(['baz']);
     });
 
     it('gets previous', async () => {
@@ -123,8 +135,8 @@ describe('connection pool', () => {
 
       it('includes previous values', async () => {
         expect(await client.put('foo1').value('updated').getPrevious()).to.containSubset({
-            key: new Buffer('foo1'),
-            value: new Buffer('bar1'),
+          key: new Buffer('foo1'),
+          value: new Buffer('bar1'),
         });
       });
     });
@@ -169,7 +181,7 @@ describe('connection pool', () => {
     it('provides basic lease lifecycle', async () => {
       lease = client.lease(100);
       await lease.put('leased').value('foo');
-      expect((await client.get('leased')).kvs[0].lease).to.equal(await lease.grant());
+      expect((await client.get('leased').exec()).kvs[0].lease).to.equal(await lease.grant());
       await lease.revoke();
       expect(await client.get('leased').buffer()).to.be.null;
     });


### PR DESCRIPTION
These are slightly more opinionated changes. Strings are now returned by default from the single "get" builder, and the multi "get" builder returns a map of strings to strings. This makes the API a little more ergonomic to use. Although etcd uses binary internally, its official Go client uses strings for all data types, and strings are probably going to be the most commonly-stored type of data in etcd. It's still possible to get at the raw Buffers via the lower-level exec() functions, or buffer/s() functions, but strings are default.

The range retriever now returns a JSON object. This makes more sense for many use cases.

The range retriever will also automatically slice off the prefix when one is provided. This is probably the most opinionated change--for our internal use, this makes life easy since we normally store things for service discovery in `service/{some uuid}` and end up having to slice off the prefix by hand.