### PR TITLE
Fixed bad url in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ client.put('foo').value('bar')
 
 ### API Documentation
 
-Our [TypeDoc docs are available here](https://watchbeam.github.io/etcd3/classes/index_.etcd3.html).
+Our [TypeDoc docs are available here](https://mixer.github.io/etcd3/classes/index_.etcd3.html).
 
 Our [test cases](https://github.com/WatchBeam/etcd3/blob/master/test/kv.test.ts) are also quite readable.
 


### PR DESCRIPTION
I was having trouble following the link to the docs from the repo readme.  The TypeDoc docs url in the readme was: https://watchbeam.github.io/etcd3/classes/index_.etcd3.html.  

Changed to: https://mixer.github.io/etcd3/classes/index_.etcd3.html

Now the link to the docs in the readme points to the correct url.

