### PR TITLE
Namespacing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,16 @@
+## 0.2.1 TBA
+
+ - **feature**: add namespacing capability ([#12](https://github.com/mixer/etcd3/pull/12))
+
 ## 0.2.0 2017-06-03
- 
+
  - **breaking**: return strings from `client.get()` and maps of strings from `client.getAll()` by default ([#6](https://github.com/mixer/etcd3/pull/6))
  - **breaking**: enums (which were not correctly typed in 0.1.x) have had their typings corrected and their capitalization has changed to UpperCameCase to align with TypeScript/JavaScript conventions ([#6](https://github.com/mixer/etcd3/pull/6))
  - **feature**: add transaction builder ([#4](https://github.com/mixer/etcd3/pull/4))
  - **feature**: add distributed locking ([#5](https://github.com/mixer/etcd3/pull/5))
- - **feature**: add support for password auth, TLS, client credentials ([#7](https://github.com/mixer/etcd3/pull/7))
- - **feature**: add high-level role management structures ([#7](https://github.com/mixer/etcd3/pull/7))
- - **bug**: fix enum typings being incorrect ([#7](https://github.com/mixer/etcd3/pull/7))
+ - **feature**: add support for password auth, TLS, client credentials ([#11](https://github.com/mixer/etcd3/pull/11))
+ - **feature**: add high-level role management structures ([#11](https://github.com/mixer/etcd3/pull/11))
+ - **bug**: fix enum typings being incorrect ([#11](https://github.com/mixer/etcd3/pull/11))
  - **doc**: update URLs in the readme and package.json
 
 ## 0.1.2 2017-04-13

--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,9 @@
  - **breaking**: enums (which were not correctly typed in 0.1.x) have had their typings corrected and their capitalization has changed to UpperCameCase to align with TypeScript/JavaScript conventions ([#6](https://github.com/mixer/etcd3/pull/6))
  - **feature**: add transaction builder ([#4](https://github.com/mixer/etcd3/pull/4))
  - **feature**: add distributed locking ([#5](https://github.com/mixer/etcd3/pull/5))
- - **feature**: add support for password auth, TLS, client credentials ([#6](https://github.com/mixer/etcd3/pull/6))
- - **feature**: add high-level role management structures ([#6](https://github.com/mixer/etcd3/pull/6))
- - **bug**: fix enum typings being incorrect ([#6](https://github.com/mixer/etcd3/pull/6))
+ - **feature**: add support for password auth, TLS, client credentials ([#7](https://github.com/mixer/etcd3/pull/7))
+ - **feature**: add high-level role management structures ([#7](https://github.com/mixer/etcd3/pull/7))
+ - **bug**: fix enum typings being incorrect ([#7](https://github.com/mixer/etcd3/pull/7))
  - **doc**: update URLs in the readme and package.json
 
 ## 0.1.2 2017-04-13

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,11 @@
+/**
+ * Thrown when an internal assertion fails.
+ */
+export class ClientRuntimeError extends Error {
+  constructor(message: string) {
+    super(`${message} Please report this error at https://github.com/mixer/etcd3`);
+  }
+}
 
 /**
  * A GRPCGenericError is rejected via the connection when some error occurs

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,0 +1,118 @@
+import * as Builder from './builder';
+import { ConnectionPool } from './connection-pool';
+import { Lease } from './lease';
+import { Lock } from './lock';
+import { Rangable, Range } from './range';
+import * as RPC from './rpc';
+import { NSApplicator, toBuffer } from './util';
+
+/**
+ * Namespace is the class on which CRUD operations can be invoked. The default
+ * namespace is the empty string, "". You can create nested namespaces by
+ * calling the `namespace(prefix)` method.
+ *
+ * For example, if the current namespace is the default "" and you call
+ * namespace('user1/'), all operations on that new namespace will be
+ * automatically prefixed with `user1/`:
+ *
+ * ```
+ * const client = new Etcd3();
+ * const ns = client.namespace('user1/');
+ *
+ * await ns.put('foo').value('bar'); // sets the key `user1/foo` to `bar`
+ * await ns.delete().all(); // deletes all keys with the prefix `user1/`
+ * ```
+ *
+ * Namespacing is particularly useful to avoid clashing between multiple
+ * applications and when using Etcd's access control.
+ */
+export class Namespace {
+  private readonly nsApplicator = new NSApplicator(this.prefix);
+  public readonly kv = new RPC.KVClient(this.pool);
+  public readonly leaseClient = new RPC.LeaseClient(this.pool);
+  public readonly watch = new RPC.WatchClient(this.pool);
+
+  constructor(
+    protected readonly prefix: Buffer,
+    protected readonly pool: ConnectionPool,
+  ) {}
+
+  /**
+   * `.get()` starts a query to look up a single key from etcd.
+   */
+  public get(key: string): Builder.SingleRangeBuilder {
+    return new Builder.SingleRangeBuilder(this.kv, this.nsApplicator, key);
+  }
+
+  /**
+   * `.getAll()` starts a query to look up multiple keys from etcd.
+   */
+  public getAll(): Builder.MultiRangeBuilder {
+    return new Builder.MultiRangeBuilder(this.kv, this.nsApplicator);
+  }
+
+  /**
+   * `.put()` starts making a put request against etcd.
+   */
+  public put(key: string | Buffer): Builder.PutBuilder {
+    return new Builder.PutBuilder(this.kv, this.nsApplicator, key);
+  }
+
+  /**
+   * `.delete()` starts making a delete request against etcd.
+   */
+  public delete(): Builder.DeleteBuilder {
+    return new Builder.DeleteBuilder(this.kv, this.nsApplicator);
+  }
+
+  /**
+   * `lease()` grants and returns a new Lease instance. The Lease is
+   * automatically kept alive for you until it is revoked. See the
+   * documentation on the Lease class for some examples.
+   */
+  public lease(ttl: number): Lease {
+    return new Lease(this.pool, this.nsApplicator, ttl);
+  }
+
+  /**
+   * `lock()` is a helper to provide distributed locking capability. See
+   * the documentation on the Lock class for more information and examples.
+   */
+  public lock(key: string | Buffer): Lock {
+    return new Lock(this.pool, this.nsApplicator, key);
+  }
+
+  /**
+   * `if()` starts a new etcd transaction, which allows you to execute complex
+   * statements atomically. See documentation on the ComparatorBuilder for
+   * more information.
+   */
+  public if(
+    key: string | Buffer,
+    column: keyof typeof Builder.compareTarget,
+    cmp: keyof typeof Builder.comparator,
+    value: string | Buffer | number,
+  ): Builder.ComparatorBuilder {
+    return new Builder.ComparatorBuilder(this.kv, this.nsApplicator)
+      .and(key, column, cmp, value);
+  }
+
+  /**
+   * Creates a structure representing an etcd range. Used in permission grants
+   * and queries. This is a convenience method for `Etcd3.Range.from(...)`.
+   */
+  public range(r: Rangable): Range {
+    return Range.from(r);
+  }
+
+  /**
+   * namespace adds a prefix and returns a new Namespace, which is used for
+   * operating on keys in a prefixed domain. For example, if the current
+   * namespace is the default "" and you call namespace('user1/'), all
+   * operations on that new namespace will be automatically prefixed
+   * with `user1/`. See the Namespace class for more details.
+   */
+  public namespace(prefix: string | Buffer): Namespace {
+    return new Namespace(Buffer.concat([this.prefix, toBuffer(prefix)]), this.pool);
+  }
+}

--- a/src/range.ts
+++ b/src/range.ts
@@ -1,7 +1,4 @@
-import { toBuffer } from './util';
-
-const zeroKey = Buffer.from([0]);
-const emptyKey = Buffer.from([]);
+import { emptyKey, endRangeForPrefix, toBuffer, zeroKey } from './util';
 
 function compare(a: Buffer, b: Buffer) {
   if (a.length === 0) {
@@ -78,17 +75,7 @@ export class Range {
       return new Range(zeroKey, zeroKey);
     }
 
-    const start = toBuffer(prefix);
-    let end = Buffer.from(start); // copy to prevent mutation
-    for (let i = end.length - 1; i >= 0; i--) {
-      if (end[i] < 0xff) {
-        end[i]++;
-        end = end.slice(0, i + 1);
-        return new Range(start, end);
-      }
-    }
-
-    return new Range(start, zeroKey);
+    return new Range(prefix, endRangeForPrefix(toBuffer(prefix)));
   }
 
   /**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -14,6 +14,7 @@ import {
   EtcdUserNotFoundError,
   GRPCConnectFailedError,
   Lease,
+  Namespace,
   Role,
 } from '../src';
 import { getOptions } from './util';
@@ -65,6 +66,58 @@ describe('client', () => {
     expect(mock.exec.calledWith('KV', 'range')).to.be.true;
     client.unmock();
     expect(await client.get('foo1').string()).to.equal('bar1');
+  });
+
+  describe('namespacing', () => {
+    let ns: Namespace;
+    beforeEach(() => ns = client.namespace('user1/'));
+
+    const assertEqualInNamespace = async (key: string, value: string) => {
+      expect(await ns.get(key)).to.equal(value);
+      expect(await client.get(`user1/${key}`)).to.equal(value);
+    };
+
+    it('puts and gets values in the namespace', async () => {
+      await ns.put('foo').value('');
+      await assertEqualInNamespace('foo', '');
+      expect(await ns.getAll().strings()).to.deep.equal({ foo: '' });
+    });
+
+    it('deletes values in the namespace', async () => {
+      await ns.put('foo1').value('');
+      await ns.put('foo2').value('');
+
+      await ns.delete().key('foo1');
+      expect(await ns.getAll().strings()).to.deep.equal({ foo2: '' });
+      await ns.delete().all();
+
+      expect(await ns.getAll().strings()).to.deep.equal({});
+      expect(await client.getAll().keys()).to.have.length.greaterThan(0);
+    });
+
+    it('contains leases in the namespace', async () => {
+      const lease = ns.lease(100);
+      await lease.put('leased').value('');
+      await assertEqualInNamespace('leased', '');
+      await lease.revoke();
+    });
+
+    it('contains locks in the namespace', async () => {
+      const lock = ns.lock('mylock');
+      await lock.acquire();
+      expect(await ns.get('mylock')).to.not.be.null;
+      expect(await client.get('user1/mylock')).to.not.be.null;
+      await lock.release();
+    });
+
+    it('runs a simple if', async () => {
+      await ns.put('foo1').value('potatoes');
+      await ns.if('foo1', 'Value', '==', 'potatoes')
+        .then(ns.put('foo1').value('tomatoes'))
+        .commit();
+
+      await assertEqualInNamespace('foo1', 'tomatoes');
+    });
   });
 
   describe('get() / getAll()', () => {


### PR DESCRIPTION
Described pretty well, with an example, in the Namespace class:

> Namespace is the class on which CRUD operations can be invoked. The default
> namespace is the empty string, "". You can create nested namespaces by
> calling the `namespace(prefix)` method.
>
> For example, if the current namespace is the default "" and you call
> namespace('user1/'), all operations on that new namespace will be
> automatically prefixed with `user1/`:
>
> ```js
> const client = new Etcd3();
> const ns = client.namespace('user1/');
>
> await ns.put('foo').value('bar'); // sets the key `user1/foo` to `bar`
> await ns.delete().all(); // deletes all keys with the prefix `user1/`
> ```
>
> Namespacing is particularly useful to avoid clashing between multiple
> applications and when using Etcd's access control.