### PR TITLE
fix(connection-pool): auto-detect https prefix, warn on bad configuration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
-## TBA
+## 0.2.4 2017-08-02
 
+ - **bug**: connections failing when an `https` prefix is provided ([#29](https://github.com/mixer/etcd3/pull/29) thanks to [@jmreicha](https://github.com/jmreicha)
+ - **bug**: connections failing when using SSL without a custom root cert ([#29](https://github.com/mixer/etcd3/pull/29) thanks to [@jmreicha](https://github.com/jmreicha)
+ - **feature**: throw a more meaningful error when using credentials without SSL ([#29](https://github.com/mixer/etcd3/pull/29))
  - **test**: run tests with Node 8 and etcd3.2 ([#27](https://github.com/mixer/etcd3/pull/27)) thanks to [@shakefu](https://github.com/shakefu)
 
 ## 0.2.3 2017-07-19

--- a/src/connection-pool.ts
+++ b/src/connection-pool.ts
@@ -21,7 +21,7 @@ const secureProtocolPrefix = 'https:';
  * Strips the https?:// from the start of the connection string.
  * @param {string} name [description]
  */
-function removeProtocolPrefix (name: string) {
+function removeProtocolPrefix(name: string) {
   return name.replace(/^https?:\/\//, '');
 }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -345,11 +345,11 @@ export interface IRangeRequest {
   /**
    * sort_order is the order for returned sorted results.
    */
-  sort_order?: (SortOrder | keyof typeof SortOrder);
+  sort_order?: SortOrder | keyof typeof SortOrder;
   /**
    * sort_target is the key-value field to use for sorting.
    */
-  sort_target?: (SortTarget | keyof typeof SortTarget);
+  sort_target?: SortTarget | keyof typeof SortTarget;
   /**
    * serializable sets the range request to use serializable member-local reads.
    * Range requests are linearizable by default; linearizable requests have higher
@@ -497,11 +497,11 @@ export interface ICompare {
   /**
    * result is logical comparison operation for this comparison.
    */
-  result?: (CompareResult | keyof typeof CompareResult);
+  result?: CompareResult | keyof typeof CompareResult;
   /**
    * target is the key-value field to inspect for the comparison.
    */
-  target?: (CompareTarget | keyof typeof CompareTarget);
+  target?: CompareTarget | keyof typeof CompareTarget;
   /**
    * key is the subject key for the comparison operation.
    */
@@ -842,7 +842,7 @@ export interface IAlarmRequest {
    * may GET alarm statuses, ACTIVATE an alarm, or DEACTIVATE a
    * raised alarm.
    */
-  action?: (AlarmAction | keyof typeof AlarmAction);
+  action?: AlarmAction | keyof typeof AlarmAction;
   /**
    * memberID is the ID of the member associated with the alarm. If memberID is 0, the
    * alarm request covers all members.
@@ -851,7 +851,7 @@ export interface IAlarmRequest {
   /**
    * alarm is the type of alarm to consider for this request.
    */
-  alarm?: (AlarmType | keyof typeof AlarmType);
+  alarm?: AlarmType | keyof typeof AlarmType;
 }
 export interface IAlarmMember {
   /**

--- a/src/types/grpc.d.ts
+++ b/src/types/grpc.d.ts
@@ -184,7 +184,7 @@ export namespace credentials {
    * the second and third arguments must be passed.
    */
   export function createSsl(
-    rootCerts: Buffer,
+    rootCerts?: Buffer,
     privateKey?: Buffer,
     certChain?: Buffer,
   ): CallCredentials;
@@ -213,10 +213,10 @@ export namespace credentials {
    * IMetadataGenerator can be passed into createFromMetadataGenerator.
    */
   export interface IMetadataGenerator {
-    (target: { service_url: string }, callback: (
-      error: Error | null,
-      metadata?: Metadata,
-    ) => void): void;
+    (
+      target: { service_url: string },
+      callback: (error: Error | null, metadata?: Metadata) => void,
+    ): void;
   }
 
   /**

--- a/test/connection-pool.test.ts
+++ b/test/connection-pool.test.ts
@@ -33,6 +33,33 @@ describe('connection pool', () => {
     await kv.deleteRange({ key });
   });
 
+  it('rejects instantiating with a mix of secure and unsecure hosts', () => {
+    expect(
+      () =>
+        new ConnectionPool(
+          getOptions({
+            hosts: ['https://server1', 'http://server2'], // tslint:disable-line
+            credentials: undefined,
+          }),
+        ),
+    ).to.throw(/mix of secure and insecure hosts/);
+  });
+
+  it('rejects passing a password with insecure hosts', () => {
+    // Some people opened issues about this, so rather than letting grpc throw
+    // its cryptic error, let's make sure we throw a nicer one.
+    expect(
+      () =>
+        new ConnectionPool(
+          getOptions({
+            hosts: 'http://server1', // tslint:disable-line
+            credentials: undefined,
+            auth: { username: 'connor', password: 'password' },
+          }),
+        ),
+    ).to.throw(/grpc does not allow/);
+  });
+
   it('rejects hitting invalid hosts', () => {
     pool = new ConnectionPool(getOptionsWithBadHost());
     const kv = new KVClient(pool);


### PR DESCRIPTION
Resolves https://github.com/mixer/etcd3/issues/28 and adds a more verbose error while we're at it as brought up in https://github.com/mixer/etcd3/issues/20. https://github.com/grpc/grpc/pull/12036 is related and what caused me to implement this incorrectly in the first place 😄 