### PR TITLE
Watcher fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,11 @@
+### 0.2.5 TBA
+
+ - **bug**: error thrown when the connection pool is drain / no servers are available ([#33](https://github.com/mixer/etcd3/pull/33), [#7](https://github.com/mixer/etcd3/issues/7)) thanks to [@SimonSchick](https://github.com/SimonSchick)
+
 ## 0.2.4 2017-08-02
 
- - **bug**: connections failing when an `https` prefix is provided ([#29](https://github.com/mixer/etcd3/pull/29) thanks to [@jmreicha](https://github.com/jmreicha)
- - **bug**: connections failing when using SSL without a custom root cert ([#29](https://github.com/mixer/etcd3/pull/29) thanks to [@jmreicha](https://github.com/jmreicha)
+ - **bug**: connections failing when an `https` prefix is provided ([#29](https://github.com/mixer/etcd3/pull/29)) thanks to [@jmreicha](https://github.com/jmreicha)
+ - **bug**: connections failing when using SSL without a custom root cert ([#29](https://github.com/mixer/etcd3/pull/29)) thanks to [@jmreicha](https://github.com/jmreicha)
  - **feature**: throw a more meaningful error when using credentials without SSL ([#29](https://github.com/mixer/etcd3/pull/29))
  - **test**: run tests with Node 8 and etcd3.2 ([#27](https://github.com/mixer/etcd3/pull/27)) thanks to [@shakefu](https://github.com/shakefu)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### 0.2.5 TBA
 
+ - **bug**: watchers response ack's could be delivered incorrectly when watching keys concurrently ([#33](https://github.com/mixer/etcd3/pull/33), [#30](https://github.com/mixer/etcd3/issues/30)) thanks to [@styleex](https://github.com/styleex)
+ - **bug**: watchers not receiving events after reconnection in rare cases ([#33](https://github.com/mixer/etcd3/pull/33), [#31](https://github.com/mixer/etcd3/issues/31)) thanks to [@styleex](https://github.com/styleex)
  - **bug**: error thrown when the connection pool is drain / no servers are available ([#33](https://github.com/mixer/etcd3/pull/33), [#7](https://github.com/mixer/etcd3/issues/7)) thanks to [@SimonSchick](https://github.com/SimonSchick)
 
 ## 0.2.4 2017-08-02

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -32,7 +32,7 @@ export class Namespace {
   public readonly kv = new RPC.KVClient(this.pool);
   public readonly leaseClient = new RPC.LeaseClient(this.pool);
   public readonly watchClient = new RPC.WatchClient(this.pool);
-  private readonly watchManager = new WatchManager(this.watchClient);
+  private readonly watchManager = new WatchManager(this.watchClient, this.kv);
 
   constructor(protected readonly prefix: Buffer, protected readonly pool: ConnectionPool) {}
   /**

--- a/src/shared-pool.ts
+++ b/src/shared-pool.ts
@@ -57,7 +57,7 @@ export class SharedPool<T> {
       return Promise.resolve(lastChosen.resource);
     }
 
-    const nextAvailable = minBy(available, r => r.availableAfter);
+    const nextAvailable = minBy(this.resources, r => r.availableAfter);
     this.contentionCount++;
 
     return delay(nextAvailable[0].availableAfter - now).then(() => {


### PR DESCRIPTION
https://github.com/mixer/etcd3/issues/7 was easy, I happened to run across it

https://github.com/mixer/etcd3/issues/30 was implemented by queuing. More ugly statefulness, yay!

https://github.com/mixer/etcd3/issues/31 seems to happen only when previous data from etcd is wiped. This causes the db's `revision` to be behind the watcher's last seen revision. When the watcher was reconnected, it asked for history since that revision, not knowing that the revision is now _ahead_ of what the database actually has. This caused the watcher to not fire until the new DB exceeded the old revision. @styleex are you able to confirm whether this matches what you saw?

My patch here was to have the watch queue-er look up the last database revision if we ask it to reconnect an existing watcher. The watcher's revision is then set to the minimum of the database's revision and the revision that it previously saw.