### PR TITLE
Allow credentials over insecure channel

### DIFF
--- a/src/connection-pool.ts
+++ b/src/connection-pool.ts
@@ -87,7 +87,7 @@ class Authenticator {
               original,
               this.createMetadataAugmenter(token),
             );
-          } catch(e) {
+          } catch (e) {
             // The the token in meta of the singleton
             SimpleToken.Instance.setToken(token);
 

--- a/src/simple-token.ts
+++ b/src/simple-token.ts
@@ -1,5 +1,9 @@
 import * as grpc from 'grpc';
 
+/**
+ * A singleton to set a token and put it inside a grpc.Metadata object.
+ * Before calls, the metadata object will be asked and pass to the exec function.
+ */
 export class SimpleToken {
 
     private static _instance: SimpleToken;

--- a/test/connection-pool.test.ts
+++ b/test/connection-pool.test.ts
@@ -45,21 +45,6 @@ describe('connection pool', () => {
     ).to.throw(/mix of secure and insecure hosts/);
   });
 
-  it('rejects passing a password with insecure hosts', () => {
-    // Some people opened issues about this, so rather than letting grpc throw
-    // its cryptic error, let's make sure we throw a nicer one.
-    expect(
-      () =>
-        new ConnectionPool(
-          getOptions({
-            hosts: 'http://server1', // tslint:disable-line
-            credentials: undefined,
-            auth: { username: 'connor', password: 'password' },
-          }),
-        ),
-    ).to.throw(/grpc does not allow/);
-  });
-
   it('rejects hitting invalid hosts', () => {
     pool = new ConnectionPool(getOptionsWithBadHost());
     const kv = new KVClient(pool);


### PR DESCRIPTION
If a user want to connect etcd with name/password without ssl, he can do that via token inside metadata object.

If the ```connection-pool#combineChannelCredentials``` throw an error (meaning we have an insecure channel), we just set the token to a singleton.

This metadata value will be retrieve when a call is performed.