### PR TITLE
chore(package): bump grpc to ^1.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 6
   - 8
+  - 10
 env:
   - ETCD_VER=v3.1.5
   - ETCD_VER=v3.2.4

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
   },
   "dependencies": {
     "bignumber.js": "^4.1.0",
-    "grpc": "~1.8.4"
+    "grpc": "^1.10.1"
   }
 }


### PR DESCRIPTION
It seems https://github.com/mixer/etcd3/issues/59 has been fixed in https://github.com/grpc/grpc-node/pull/179.

And grpc 1.8.x seems can't be compiled under Node.js 10.