### PR TITLE
Improves mock support

### DIFF
--- a/src/connection-pool.ts
+++ b/src/connection-pool.ts
@@ -272,6 +272,9 @@ export class ConnectionPool implements ICallable<Host> {
    * @override
    */
   public markFailed(host: Host) {
+    if (this.mockImpl) {
+      return;
+    }
     this.pool.fail(host);
   }
 


### PR DESCRIPTION
I have mock connection to simulate a etcd's watcher disconnection.

https://github.com/CoorpAcademy/squirrel/blob/11d14be3b0a200fd8b54fbaf8265181ee9434a74/src/etcd/test/watch.js#L74

Since v0.2.11, my tests doesn't pass anymore. `connectionPool.markFailed` souldn't throw error on mocked connection.