### PR TITLE
Add return statement for leaking promises

### DIFF
--- a/src/lease.ts
+++ b/src/lease.ts
@@ -314,14 +314,14 @@ export class Lease extends EventEmitter {
         });
 
         this.emit('keepaliveEstablished');
-        this.fireKeepAlive(stream);
+        return this.fireKeepAlive(stream);
       })
       .catch(err => this.handleKeepaliveError(err));
   }
 
   private fireKeepAlive(stream: RPC.IRequestStream<RPC.ILeaseKeepAliveRequest>) {
     this.emit('keepaliveFired');
-    this.grant()
+    return this.grant()
       .then(id => stream.write({ ID: id }))
       .catch(() => this.close()); // will only throw if the initial grant failed
   }


### PR DESCRIPTION
While working with ETCD and using `bluebird` encountered a raised warning about leaking promises:
```
(node:12941) Warning: a promise was created in a handler at .../node_modules/etcd3/lib/src/lease.js:225:18 but was not returned from it, see http://goo.gl/rRqMUw
    at Promise.then (.../node_modules/bluebird/js/release/promise.js:125:17)
```

Don't think it worth separate unit test. Just add proper returns to the code to solve the issue.